### PR TITLE
Add support for custom geoJson layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Usage
     var map = L.map('map').fitWorld();
     ...
     L.Control.fileLayerLoad({
-        // Allows you to use a customized version of `L.geoJson`.  For example if you are using the Proj4Leaflet leaflet plugin, you can pass `L.Proj.geoJson` to tell the fileloader to load the files into the L.Proj.GeoJson instead of the L.geoJson.  
+        // Allows you to use a customized version of L.geoJson.  
+        // For example if you are using the Proj4Leaflet leaflet plugin, 
+        // you can pass L.Proj.geoJson and load the files into the
+        // L.Proj.GeoJson instead of the L.geoJson.  
         layer: L.geoJson,
         // See http://leafletjs.com/reference.html#geojson-options
         layerOptions: {style: {color:'red'}},

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage
     var map = L.map('map').fitWorld();
     ...
     L.Control.fileLayerLoad({
-        // Allows you to use a customized version of the L.geoJson.
+        // Allows you to use a customized version of `L.geoJson`.  For example if you are using the Proj4Leaflet leaflet plugin, you can pass `L.Proj.geoJson` to tell the fileloader to load the files into the L.Proj.GeoJson instead of the L.geoJson.  
         layer: L.geoJson,
         // See http://leafletjs.com/reference.html#geojson-options
         layerOptions: {style: {color:'red'}},

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Usage
     var map = L.map('map').fitWorld();
     ...
     L.Control.fileLayerLoad({
+        // Allows you to use a customized version of the L.geoJson.
+        layer: L.geoJson,
         // See http://leafletjs.com/reference.html#geojson-options
         layerOptions: {style: {color:'red'}},
         // Add to map after loading (default: true) ?

--- a/leaflet.filelayer.js
+++ b/leaflet.filelayer.js
@@ -8,6 +8,7 @@
 var FileLoader = L.Class.extend({
     includes: L.Mixin.Events,
     options: {
+        layer: L.geoJson,
         layerOptions: {},
         fileSizeLimit: 1024
     },
@@ -63,7 +64,7 @@ var FileLoader = L.Class.extend({
         if (typeof content == 'string') {
             content = JSON.parse(content);
         }
-        var layer = L.geoJson(content, this.options.layerOptions);
+        var layer = this.options.layer(content, this.options.layerOptions);
 
         if (layer.getLayers().length === 0) {
             throw new Error('GeoJSON has no valid layers.');


### PR DESCRIPTION
This modification allows users to pass an alternative to `L.geoJson` layer type to allow users to use this plugin in coordination with other leaflet plugins such as Proj4Leaflet which extend the 'L.geoJson' class.