### PR TITLE
Preventing files from being loaded outside of map container

### DIFF
--- a/leaflet.filelayer.js
+++ b/leaflet.filelayer.js
@@ -149,6 +149,12 @@ L.Control.FileLayerLoad = L.Control.extend({
         };
         for (var name in callbacks)
             dropbox.addEventListener(name, callbacks[name], false);
+            
+        // For maps which are not fullscreen this will prevent dragging and
+        // dropping a file outside of map container from loading the file as a new webpage.
+        L.DomEvent.on(L.DomUtil.get(window), "dragover drop", function(e) {
+            L.DomEvent.preventDefault(e);
+        });
     },
 
     _initContainer: function () {


### PR DESCRIPTION
This change prevents files which are dropped outside the dropbox from having any effect.

Do you think we should add an option so users can toggle whether they want the entire page to be a dropbox or just the map?  