### PR TITLE
Treat .json as geojson

### DIFF
--- a/leaflet.filelayer.js
+++ b/leaflet.filelayer.js
@@ -19,6 +19,7 @@ var FileLoader = L.Class.extend({
 
         this._parsers = {
             'geojson': this._loadGeoJSON,
+            'json': this._loadGeoJSON,
             'gpx': this._convertToGeoJSON,
             'kml': this._convertToGeoJSON
         };


### PR DESCRIPTION
Following up on the old issue #18. I left the eval part alone, but added the line to treat .json like .geojson.