### PR TITLE
Added abitlity to load from an already loaded file content (e.g. loaded from URL)

### DIFF
--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -60,24 +60,23 @@
         },
 
         load: function (file /* File */) {
-            var ext;
             var reader;
             var parser;
 
             // Check file is defined
             if (this._isParameterMissing(file, 'file')) {
-                return;
+                return false;
             }
 
             // Check file size
             if (!this._isFileSizeOk(file.size)) {
-                return;
+                return false;
             }
 
             // Get parser for this data type
             parser = this._getParser(file.name);
             if (!parser) {
-                return;
+                return false;
             }
 
             // Read selected file using HTML5 File API
@@ -87,12 +86,17 @@
                 try {
                     this.fire('data:loading', { filename: file.name, format: parser.ext });
                     layer = parser.processor.call(this, e.target.result, parser.ext);
-                    this.fire('data:loaded', { layer: layer, filename: file.name, format: parser.ext });
+                    this.fire('data:loaded', {
+                        layer: layer,
+                        filename: file.name,
+                        format: parser.ext
+                    });
                 } catch (err) {
                     this.fire('data:error', { error: err });
                 }
             }, this);
-            // Testing trick: tests don't pass a real file, but an object with file.testing set to true. 
+            // Testing trick: tests don't pass a real file,
+            // but an object with file.testing set to true.
             // This object cannot be read by reader, just skip it.
             if (!file.testing) {
                 reader.readAsText(file);
@@ -103,10 +107,11 @@
 
         loadData: function (data, name, ext) {
             var parser;
+            var layer;
 
             // Check required parameters
-            if ((this._isParameterMissing(data, "data"))
-              || (this._isParameterMissing(name, "name"))) {
+            if ((this._isParameterMissing(data, 'data'))
+              || (this._isParameterMissing(name, 'name'))) {
                 return;
             }
 
@@ -122,19 +127,21 @@
             }
 
             // Process data
-            var layer;
             try {
                 this.fire('data:loading', { filename: name, format: parser.ext });
                 layer = parser.processor.call(this, data, parser.ext);
-                this.fire('data:loaded', { layer: layer, filename: name, format: parser.ext });
+                this.fire('data:loaded', {
+                    layer: layer,
+                    filename: name,
+                    format: parser.ext
+                });
             } catch (err) {
                 this.fire('data:error', { error: err });
             }
-
         },
 
-        _isParameterMissing: function (v, vname, vtype) {
-            if (typeof v === "undefined") {
+        _isParameterMissing: function (v, vname) {
+            if (typeof v === 'undefined') {
                 this.fire('data:error', {
                     error: new Error('Missing parameter: ' + vname)
                 });
@@ -145,7 +152,7 @@
 
         _getParser: function (name, ext) {
             var parser;
-            ext = ext ? ext : name.split('.').pop();
+            ext = ext || name.split('.').pop();
             parser = this._parsers[ext];
             if (!parser) {
                 this.fire('data:error', {
@@ -154,8 +161,8 @@
                 return undefined;
             }
             return {
-                "processor": parser,
-                "ext": ext
+                processor: parser,
+                ext: ext
             };
         },
 

--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -63,8 +63,104 @@
             var ext;
             var reader;
             var parser;
+
+            // Check file is defined
+            if (this._isParameterMissing(file, 'file')) {
+                return;
+            }
+
             // Check file size
-            var fileSize = (file.size / 1024).toFixed(4);
+            if (!this._isFileSizeOk(file.size)) {
+                return;
+            }
+
+            // Get parser for this data type
+            parser = this._getParser(file.name);
+            if (!parser) {
+                return;
+            }
+
+            // Read selected file using HTML5 File API
+            reader = new FileReader();
+            reader.onload = L.Util.bind(function (e) {
+                var layer;
+                try {
+                    this.fire('data:loading', { filename: file.name, format: parser.ext });
+                    layer = parser.processor.call(this, e.target.result, parser.ext);
+                    this.fire('data:loaded', { layer: layer, filename: file.name, format: parser.ext });
+                } catch (err) {
+                    this.fire('data:error', { error: err });
+                }
+            }, this);
+            // Testing trick: tests don't pass a real file, but an object with file.testing set to true. 
+            // This object cannot be read by reader, just skip it.
+            if (!file.testing) {
+                reader.readAsText(file);
+            }
+            // We return this to ease testing
+            return reader;
+        },
+
+        loadData: function (data, name, ext) {
+            var parser;
+
+            // Check required parameters
+            if ((this._isParameterMissing(data, "data"))
+              || (this._isParameterMissing(name, "name"))) {
+                return;
+            }
+
+            // Check file size
+            if (!this._isFileSizeOk(data.length)) {
+                return;
+            }
+
+            // Get parser for this data type
+            parser = this._getParser(name, ext);
+            if (!parser) {
+                return;
+            }
+
+            // Process data
+            var layer;
+            try {
+                this.fire('data:loading', { filename: name, format: parser.ext });
+                layer = parser.processor.call(this, data, parser.ext);
+                this.fire('data:loaded', { layer: layer, filename: name, format: parser.ext });
+            } catch (err) {
+                this.fire('data:error', { error: err });
+            }
+
+        },
+
+        _isParameterMissing: function (v, vname, vtype) {
+            if (typeof v === "undefined") {
+                this.fire('data:error', {
+                    error: new Error('Missing parameter: ' + vname)
+                });
+                return true;
+            }
+            return false;
+        },
+
+        _getParser: function (name, ext) {
+            var parser;
+            ext = ext ? ext : name.split('.').pop();
+            parser = this._parsers[ext];
+            if (!parser) {
+                this.fire('data:error', {
+                    error: new Error('Unsupported file type (' + ext + ')')
+                });
+                return undefined;
+            }
+            return {
+                "processor": parser,
+                "ext": ext
+            };
+        },
+
+        _isFileSizeOk: function (size) {
+            var fileSize = (size / 1024).toFixed(4);
             if (fileSize > this.options.fileSizeLimit) {
                 this.fire('data:error', {
                     error: new Error(
@@ -73,34 +169,9 @@
                         this.options.fileSizeLimit + 'kb)'
                     )
                 });
-                return;
+                return false;
             }
-
-            // Check file extension
-            ext = file.name.split('.').pop();
-            parser = this._parsers[ext];
-            if (!parser) {
-                this.fire('data:error', {
-                    error: new Error('Unsupported file type ' + file.type + '(' + ext + ')')
-                });
-                return;
-            }
-            // Read selected file using HTML5 File API
-            reader = new FileReader();
-            reader.onload = L.Util.bind(function (e) {
-                var layer;
-                try {
-                    this.fire('data:loading', { filename: file.name, format: ext });
-                    layer = parser.call(this, e.target.result, ext);
-                    this.fire('data:loaded', { layer: layer, filename: file.name, format: ext });
-                } catch (err) {
-                    this.fire('data:error', { error: err });
-                }
-            }, this);
-            reader.readAsText(file);
-
-            // We return this to ease testing
-            return reader;
+            return true;
         },
 
         _loadGeoJSON: function _loadGeoJSON(content) {

--- a/test/test.filelayer.js
+++ b/test/test.filelayer.js
@@ -55,7 +55,7 @@ describe('L.Control.FileLayerLoad', function() {
 
             var callback = sinon.spy();
             map.on('layeradd', callback);
-            var reader = control.loader.load({name: 'name.geojson'});
+            var reader = control.loader.load({name: 'name.geojson', testing: true});
             reader.onload({target: {result: _VALID_GEOJSON}});
 
             assert.isTrue(callback.called);
@@ -68,7 +68,7 @@ describe('L.Control.FileLayerLoad', function() {
             var callback = sinon.spy();
             map.on('layeradd', callback);
 
-            var reader = control.loader.load({name: 'name.geojson'});
+            var reader = control.loader.load({name: 'name.geojson', testing: true});
             reader.onload({target: {result: _VALID_GEOJSON}});
 
             assert.isFalse(callback.called);
@@ -97,7 +97,7 @@ describe('FileLoader', function() {
     describe('Load file', function() {
 
         it("should warn if format is not supported.", function(done) {
-            var file = {name: 'name.csv'},
+            var file = {name: 'name.csv', testing: true},
                 callback = sinon.spy();
             loader.on('data:error', callback);
             loader.load(file);
@@ -106,7 +106,7 @@ describe('FileLoader', function() {
         });
 
         it("should fire data:loading and data:loaded", function(done) {
-            var file = {name: 'name.geojson'};
+            var file = {name: 'name.geojson', testing: true};
             var loadingcb = sinon.spy(),
                 loadedcb = sinon.spy();
             loader.on('data:loading', loadingcb);
@@ -119,7 +119,7 @@ describe('FileLoader', function() {
         });
 
         it("should be able to load KML", function(done) {
-            var file = {name: 'name.kml'};
+            var file = {name: 'name.kml', testing: true};
             loader.on('data:loaded', function (e) {
                 assert.equal(e.format, 'kml');
                 assert.equal(e.filename, 'name.kml');
@@ -131,7 +131,7 @@ describe('FileLoader', function() {
         });
 
         it("should warn if size exceeds limit from option", function(done) {
-            var file = {name: 'name.kml', size: 9999999},
+            var file = {name: 'name.kml', size: 9999999, testing: true},
                 callback = sinon.spy();
             loader.on('data:error', callback);
             loader.load(file);
@@ -140,7 +140,7 @@ describe('FileLoader', function() {
         });
 
         it("should warn if imported layer has no feature", function(done) {
-            var file = {name: 'name.geojson'},
+            var file = {name: 'name.geojson', testing: true},
                 callback = sinon.spy();
             loader.on('data:error', callback);
             var reader = loader.load(file);
@@ -149,5 +149,73 @@ describe('FileLoader', function() {
             done();
         });
     });
+
+    describe('Load data', function() {
+        
+        before(function() {
+            loader.removeEventListener('data:loading');
+            loader.removeEventListener('data:loaded');
+        });
+        
+        it("should warn if format is not supported.", function(done) {
+            var name = 'name.csv',
+                data = '';
+                callback = sinon.spy();
+            loader.on('data:error', callback);
+            loader.loadData(data, name);
+            assert.isTrue(callback.calledOnce);
+            done();
+        });
+
+        it("should fire data:loading and data:loaded", function(done) {
+            var name = 'name.geojson',
+                data = _VALID_GEOJSON;
+            var loadingcb = sinon.spy(),
+                loadedcb = sinon.spy();
+            loader.on('data:loading', loadingcb);
+            loader.on('data:loaded', loadedcb);
+            var reader = loader.loadData(data, name);
+            assert.isTrue(loadingcb.called);
+            assert.isTrue(loadedcb.called);
+            done();
+        });
+
+        it("should be able to load KML", function(done) {
+            var name = 'name.kml',
+                data = _VALID_KML;
+            loader.on('data:loaded', function (e) {
+                assert.equal(e.format, 'kml');
+                assert.equal(e.filename, 'name.kml');
+                assert.isTrue(e.layer instanceof L.GeoJSON);
+                done();
+            });
+            loader.loadData(data, name);
+        });
+
+        it("should warn if size exceeds limit from option", function(done) {
+            var name = 'name.kml',
+                data  = '',
+                callback = sinon.spy();
+            for (var i = 0 ; i < 1030 ; i++) {
+              data += '0';
+            }
+            loader.on('data:error', callback);
+            loader.loadData(data, name);
+            assert.isTrue(callback.calledOnce);
+            done();
+        });
+
+        it("should warn if imported layer has no feature", function(done) {
+            var name = 'name.geojson',
+                data = {},
+                callback = sinon.spy();
+            loader.on('data:error', callback);
+            loader.loadData(data, name);
+            assert.isTrue(callback.called);
+            done();
+        });
+
+    });
+
 
 });


### PR DESCRIPTION
Added:
  - `FileLoader.loadData(data, name, ext)`  where:
      -  `data` is the input data to load (a GeoJson, GPX or KML)
      -  `name` is the name of the data (file name, URL, etc)
      -  `ext` is an optional parameter to set data type in order to force parser type
  - fire `'data:error'` if load/loadData mandatory parameters are missing
  - trick to allow testing of load file (set `file.testing` to true to skip reader load)
  - tests for `loadData`

Sample usage (with JQuery):
```
  $.get('https://my.server.com/?id=89798747&type=3', function(data){
    fileloader.loadData(data, '89798747', 'gpx');
  });

```