### PR TITLE
Added optional 'ext' parameter to the 'load' method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "5.5.0"
   - "4.2.1"
   - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ cache:
 
 install:
   - npm install
+  - npm install togeojson
+  - npm install leaflet
 
 script:
   - "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
 
 install:
   - npm install
-  - npm install togeojson
   - npm install leaflet
+  - npm install mapbox/togeojson
 
 script:
   - "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ cache:
 
 install:
   - npm install
-  - npm install leaflet
-  - npm install mapbox/togeojson
+  - npm-install-peers
 
 script:
   - "npm test"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mocha": "^3.0.2",
     "mocha-phantomjs": "^4.1.0",
     "requirejs": "^2.2.0",
-    "sinon": "^1.17.5"
+    "sinon": "^1.17.5",
+    "npm-install-peers": "^1.1.0"
   }
 }

--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -59,7 +59,7 @@
             };
         },
 
-        load: function (file /* File */) {
+        load: function (file, ext) {
             var reader;
             var parser;
 
@@ -74,7 +74,7 @@
             }
 
             // Get parser for this data type
-            parser = this._getParser(file.name);
+            parser = this._getParser(file.name, ext);
             if (!parser) {
                 return false;
             }

--- a/test/test.filelayer.js
+++ b/test/test.filelayer.js
@@ -130,6 +130,20 @@ describe('FileLoader', function() {
             reader.onload({target: {result: _VALID_KML}});
         });
 
+        it("should reject KML if GPX expected", function(done) {
+            var file = {name: 'name.kml', testing: true},
+                ext = "gpx",
+                cberr = sinon.spy(),
+                cbok = sinon.spy();
+            loader.on('data:error', cberr);
+            loader.on('data:loaded', cbok);
+            var reader = loader.load(file, ext);
+            reader.onload({target: {result: {}}});
+            assert.isTrue(cberr.called);
+            assert.isFalse(cbok.called);
+            done();
+        });
+
         it("should warn if size exceeds limit from option", function(done) {
             var file = {name: 'name.kml', size: 9999999, testing: true},
                 callback = sinon.spy();
@@ -151,12 +165,12 @@ describe('FileLoader', function() {
     });
 
     describe('Load data', function() {
-        
+
         before(function() {
             loader.removeEventListener('data:loading');
             loader.removeEventListener('data:loaded');
         });
-        
+
         it("should warn if format is not supported.", function(done) {
             var name = 'name.csv',
                 data = '';
@@ -190,6 +204,20 @@ describe('FileLoader', function() {
                 done();
             });
             loader.loadData(data, name);
+        });
+
+        it("should reject KML if GPX expected", function(done) {
+            var name = 'name.kml',
+                data = _VALID_KML,
+                ext = "gpx",
+                cberr = sinon.spy(),
+                cbok = sinon.spy();
+            loader.on('data:error', cberr);
+            loader.on('data:loaded', cbok);
+            loader.loadData(data, name, ext);
+            assert.isTrue(cberr.calledOnce);
+            assert.isFalse(cbok.calledOnce);
+            done();
         });
 
         it("should warn if size exceeds limit from option", function(done) {


### PR DESCRIPTION
Force file type when file does not have the expected extension. This is now consistent with 'loadData' method. The method is still backward compatible with former signature.

Added test for this new parameter.