### PR TITLE
Added optional 'ext' parameter to the 'load' method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "5.5.0"
   - "4.2.1"
   - "0.10"
@@ -11,6 +12,7 @@ cache:
     - node_modules
 
 install:
+  - npm install leaflet@^0.7.7 togeojson@^0.14.0
   - npm install
 
 script:

--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -59,7 +59,7 @@
             };
         },
 
-        load: function (file /* File */) {
+        load: function (file, ext) {
             var reader;
             var parser;
 
@@ -74,7 +74,7 @@
             }
 
             // Get parser for this data type
-            parser = this._getParser(file.name);
+            parser = this._getParser(file.name, ext);
             if (!parser) {
                 return false;
             }

--- a/test/test.filelayer.js
+++ b/test/test.filelayer.js
@@ -96,6 +96,12 @@ describe('FileLoader', function() {
 
     describe('Load file', function() {
 
+        beforeEach(function() {
+            loader.removeEventListener('data:loading');
+            loader.removeEventListener('data:loaded');
+            loader.removeEventListener('data:error');
+        });
+
         it("should warn if format is not supported.", function(done) {
             var file = {name: 'name.csv', testing: true},
                 callback = sinon.spy();
@@ -138,10 +144,26 @@ describe('FileLoader', function() {
             loader.on('data:error', cberr);
             loader.on('data:loaded', cbok);
             var reader = loader.load(file, ext);
-            reader.onload({target: {result: {}}});
+            reader.onload({target: {result: {result: _VALID_KML}}});
             assert.isTrue(cberr.called);
             assert.isFalse(cbok.called);
             done();
+        });
+
+        it("should be able to load KML with gpx extension", function(done) {
+            var file = {name: 'name.gpx', testing: true},
+                ext = "kml",
+                cberr = sinon.spy();
+            loader.on('data:error', cberr);;
+            loader.on('data:loaded', function (e) {
+                assert.equal(e.format, 'kml');
+                assert.equal(e.filename, 'name.gpx');
+                assert.isTrue(e.layer instanceof L.GeoJSON);
+                done();
+            });
+            var reader = loader.load(file, ext);
+            reader.onload({target: {result: _VALID_KML}});
+            assert.isFalse(cberr.called);
         });
 
         it("should warn if size exceeds limit from option", function(done) {
@@ -166,9 +188,10 @@ describe('FileLoader', function() {
 
     describe('Load data', function() {
 
-        before(function() {
+        beforeEach(function() {
             loader.removeEventListener('data:loading');
             loader.removeEventListener('data:loaded');
+            loader.removeEventListener('data:error');
         });
 
         it("should warn if format is not supported.", function(done) {
@@ -218,6 +241,22 @@ describe('FileLoader', function() {
             assert.isTrue(cberr.calledOnce);
             assert.isFalse(cbok.calledOnce);
             done();
+        });
+
+        it("should be able to load KML with gpx extension", function(done) {
+            var name = 'name.gpx',
+                data = _VALID_KML,
+                ext = "kml",
+                cberr = sinon.spy();
+            loader.on('data:error', cberr);
+            loader.on('data:loaded', function (e) {
+                assert.equal(e.format, 'kml');
+                assert.equal(e.filename, 'name.gpx');
+                assert.isTrue(e.layer instanceof L.GeoJSON);
+                done();
+            });
+            loader.loadData(data, name, ext);
+            assert.isFalse(cberr.called);
         });
 
         it("should warn if size exceeds limit from option", function(done) {

--- a/test/test.filelayer.js
+++ b/test/test.filelayer.js
@@ -130,6 +130,20 @@ describe('FileLoader', function() {
             reader.onload({target: {result: _VALID_KML}});
         });
 
+        it("should reject KML if GPX expected", function(done) {
+            var file = {name: 'name.kml', testing: true},
+                ext = "gpx",
+                cberr = sinon.spy(),
+                cbok = sinon.spy();
+            loader.on('data:error', cberr);
+            loader.on('data:loaded', cbok);
+            var reader = loader.load(file, ext);
+            reader.onload({target: {result: {}}});
+            assert.isTrue(cberr.called);
+            assert.isFalse(cbok.called);
+            done();
+        });
+
         it("should warn if size exceeds limit from option", function(done) {
             var file = {name: 'name.kml', size: 9999999, testing: true},
                 callback = sinon.spy();
@@ -151,12 +165,12 @@ describe('FileLoader', function() {
     });
 
     describe('Load data', function() {
-        
+
         before(function() {
             loader.removeEventListener('data:loading');
             loader.removeEventListener('data:loaded');
         });
-        
+
         it("should warn if format is not supported.", function(done) {
             var name = 'name.csv',
                 data = '';
@@ -190,6 +204,20 @@ describe('FileLoader', function() {
                 done();
             });
             loader.loadData(data, name);
+        });
+
+        it("should reject KML if GPX expected", function(done) {
+            var name = 'name.kml',
+                data = _VALID_KML,
+                ext = "gpx",
+                cberr = sinon.spy(),
+                cbok = sinon.spy();
+            loader.on('data:error', cberr);
+            loader.on('data:loaded', cbok);
+            loader.loadData(data, name, ext);
+            assert.isTrue(cberr.calledOnce);
+            assert.isFalse(cbok.calledOnce);
+            done();
         });
 
         it("should warn if size exceeds limit from option", function(done) {


### PR DESCRIPTION
This new paramter forces the file type when file does not have the expected extension. This is parameter is already used in 'loadData' method, both methods have now consistent signatures. This 'ext' parameter being optional, the method is still backward compatible with previous version.
Added test for this new parameter.