### PR TITLE
Added FileLoader.loadMultiple(files,ext)

### DIFF
--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -332,18 +332,6 @@
                 e.preventDefault();
             });
             return container;
-        },
-
-        _loadFiles: function (files) {
-            var fileLoader = this.loader;
-            files = Array.prototype.slice.apply(files);
-
-            setTimeout(function () {
-                fileLoader.load(files.shift());
-                if (files.length > 0) {
-                    setTimeout(arguments.callee, 25);
-                }
-            }, 25);
         }
     });
 

--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -59,8 +59,9 @@
             };
         },
 
-        load: function (file, ext, reader /* for loadMultiple tests */) {
-            var parser;
+        load: function (file, ext) {
+            var parser,
+                reader;
 
             // Check file is defined
             if (this._isParameterMissing(file, 'file')) {
@@ -79,8 +80,7 @@
             }
 
             // Read selected file using HTML5 File API
-            // for testing loadMultiple, reuse reader passed as method argument
-            if (!file.testing || !reader) reader = new FileReader();
+            reader = new FileReader();
             reader.onload = L.Util.bind(function (e) {
                 var layer;
                 try {
@@ -106,21 +106,16 @@
         },
 
         loadMultiple: function (files, ext) {
-            var reader = false;
+            var readers = [];
             if (files[0]) {
               files = Array.prototype.slice.apply(files);
-              var loadOne = L.Util.bind(function () {
-                reader = this.load(files.shift(), ext, reader);
-                if (files.length > 0) {
-                    setTimeout(loadOne, 25);
-                }
-                return reader;
-              }, this);
-              loadOne();
+              while (files.length > 0) {
+                readers.push(this.load(files.shift(), ext));
+              }
             }
             // return first reader (or false if no file),
             // which is also used for subsequent loadings
-            return reader;
+            return readers;
         },
 
         loadData: function (data, name, ext) {

--- a/test/test.filelayer.js
+++ b/test/test.filelayer.js
@@ -202,10 +202,8 @@ describe('FileLoader', function() {
                 callback = sinon.spy();
             loader.on('data:error', callback);
             loader.loadMultiple(files);
-            setTimeout(function(){
-              assert.isTrue(callback.calledTwice);
-              done();
-            }, 50);
+            assert.isTrue(callback.calledTwice);
+            done();
         });
 
         it("should fire data:loading and data:loaded", function(done) {
@@ -217,9 +215,9 @@ describe('FileLoader', function() {
               loadedcb = sinon.spy();
             loader.on('data:loading', loadingcb);
             loader.on('data:loaded', loadedcb);
-            var reader = loader.loadMultiple(files);
-            reader.onload({target: {result: _VALID_GEOJSON}});
-            reader.onload({target: {result: _VALID_GEOJSON}});
+            var readers = loader.loadMultiple(files);
+            readers[0].onload({target: {result: _VALID_GEOJSON}});
+            readers[1].onload({target: {result: _VALID_GEOJSON}});
             assert.isTrue(loadingcb.calledTwice);
             assert.isTrue(loadedcb.calledTwice);
             done();
@@ -235,8 +233,8 @@ describe('FileLoader', function() {
                 assert.isTrue(e.layer instanceof L.GeoJSON);
                 done();
             });
-            var reader = loader.loadMultiple(files);
-            reader.onload({target: {result: _VALID_KML}});
+            var readers = loader.loadMultiple(files);
+            readers[0].onload({target: {result: _VALID_KML}});
         });
 
         it("should reject KML if GPX expected", function(done) {
@@ -249,8 +247,8 @@ describe('FileLoader', function() {
                 cbok = sinon.spy();
             loader.on('data:error', cberr);
             loader.on('data:loaded', cbok);
-            var reader = loader.loadMultiple(files, ext);
-            reader.onload({target: {result: {result: _VALID_KML}}});
+            var readers = loader.loadMultiple(files, ext);
+            readers[0].onload({target: {result: {result: _VALID_KML}}});
             assert.isTrue(cberr.called);
             assert.isFalse(cbok.called);
             done();
@@ -267,18 +265,16 @@ describe('FileLoader', function() {
             loader.on('data:error', cberr);;
             loader.on('data:loaded', function (e) {
                 assert.equal(e.format, 'kml');
-                assert.isTrue(/name[12]\.gpx/.test(e.filename));
+                assert.isTrue(/name[12]\.(gpx|txt)/.test(e.filename));
                 assert.isTrue(e.layer instanceof L.GeoJSON);
                 cbloaded();
             });
-            var reader = loader.loadMultiple(files, ext);
-            reader.onload({target: {result: _VALID_KML}});
-            reader.onload({target: {result: _VALID_KML}});
-            setTimeout(function(){
-              assert.isFalse(cberr.called);
-              assert.isTrue(cbloaded.calledTwice);
-              done();
-            },50);
+            var readers = loader.loadMultiple(files, ext);
+            readers[0].onload({target: {result: _VALID_KML}});
+            readers[1].onload({target: {result: _VALID_KML}});
+            assert.isFalse(cberr.called);
+            assert.isTrue(cbloaded.calledTwice);
+            done();
         });
 
         it("should warn if size exceeds limit from option", function(done) {
@@ -302,9 +298,9 @@ describe('FileLoader', function() {
                 cbloaded = sinon.spy();
             loader.on('data:error', cberr);
             loader.on('data:loaded', cbloaded);
-            var reader = loader.loadMultiple(files);
-            reader.onload({target: {result: _VALID_GEOJSON}});
-            reader.onload({target: {result: {}}});
+            var readers = loader.loadMultiple(files);
+            readers[0].onload({target: {result: _VALID_GEOJSON}});
+            readers[1].onload({target: {result: {}}});
             assert.isTrue(cberr.calledOnce);
             assert.isTrue(cbloaded.calledOnce);
             done();
@@ -315,8 +311,8 @@ describe('FileLoader', function() {
                 callback = sinon.spy();
             loader.on('data:error', callback);
             loader.on('data:loaded', callback);
-            var reader = loader.loadMultiple(files);
-            assert.isFalse(reader);
+            var readers = loader.loadMultiple(files);
+            assert.isTrue(readers.length == 0);
             assert.isFalse(callback.called);
             done();
         });

--- a/test/test.filelayer.js
+++ b/test/test.filelayer.js
@@ -186,6 +186,142 @@ describe('FileLoader', function() {
         });
     });
 
+    describe('Load multiple files', function() {
+
+        beforeEach(function() {
+            loader.removeEventListener('data:loading');
+            loader.removeEventListener('data:loaded');
+            loader.removeEventListener('data:error');
+        });
+
+        it("should warn if format is not supported.", function(done) {
+            var files = [
+                  {name: 'name1.csv', testing: true},
+                  {name: 'name2.csv', testing: true}
+                ],
+                callback = sinon.spy();
+            loader.on('data:error', callback);
+            loader.loadMultiple(files);
+            setTimeout(function(){
+              assert.isTrue(callback.calledTwice);
+              done();
+            }, 50);
+        });
+
+        it("should fire data:loading and data:loaded", function(done) {
+            var files = [
+                {name: 'name1.geojson', testing: true},
+                {name: 'name2.geojson', testing: true}
+              ],
+              loadingcb = sinon.spy(),
+              loadedcb = sinon.spy();
+            loader.on('data:loading', loadingcb);
+            loader.on('data:loaded', loadedcb);
+            var reader = loader.loadMultiple(files);
+            reader.onload({target: {result: _VALID_GEOJSON}});
+            reader.onload({target: {result: _VALID_GEOJSON}});
+            assert.isTrue(loadingcb.calledTwice);
+            assert.isTrue(loadedcb.calledTwice);
+            done();
+        });
+
+        it("should be able to load a single KML file", function(done) {
+            var files = [
+                {name: 'name2.kml', testing: true}
+              ];
+            loader.on('data:loaded', function (e) {
+                assert.equal(e.format, 'kml');
+                assert.isTrue(/name[12]\.kml/.test(e.filename));
+                assert.isTrue(e.layer instanceof L.GeoJSON);
+                done();
+            });
+            var reader = loader.loadMultiple(files);
+            reader.onload({target: {result: _VALID_KML}});
+        });
+
+        it("should reject KML if GPX expected", function(done) {
+            var files = [
+                  {name: 'name1.kml', testing: true},
+                  {name: 'name2.gpx', testing: true}
+                ],
+                ext = "gpx",
+                cberr = sinon.spy(),
+                cbok = sinon.spy();
+            loader.on('data:error', cberr);
+            loader.on('data:loaded', cbok);
+            var reader = loader.loadMultiple(files, ext);
+            reader.onload({target: {result: {result: _VALID_KML}}});
+            assert.isTrue(cberr.called);
+            assert.isFalse(cbok.called);
+            done();
+        });
+
+        it("should be able to load KML with invalid extension", function(done) {
+            var files = [
+                  {name: 'name1.gpx', testing: true},
+                  {name: 'name2.txt', testing: true}
+                ],
+                ext = "kml",
+                cberr = sinon.spy(),
+                cbloaded = sinon.spy();
+            loader.on('data:error', cberr);;
+            loader.on('data:loaded', function (e) {
+                assert.equal(e.format, 'kml');
+                assert.isTrue(/name[12]\.gpx/.test(e.filename));
+                assert.isTrue(e.layer instanceof L.GeoJSON);
+                cbloaded();
+            });
+            var reader = loader.loadMultiple(files, ext);
+            reader.onload({target: {result: _VALID_KML}});
+            reader.onload({target: {result: _VALID_KML}});
+            setTimeout(function(){
+              assert.isFalse(cberr.called);
+              assert.isTrue(cbloaded.calledTwice);
+              done();
+            },50);
+        });
+
+        it("should warn if size exceeds limit from option", function(done) {
+            var files = [
+                  {name: 'name1.kml', size: 9999999, testing: true},
+                  {name: 'name2.kml', testing: true}
+                ],
+                callback = sinon.spy();
+            loader.on('data:error', callback);
+            loader.loadMultiple(files);
+            assert.isTrue(callback.calledOnce);
+            done();
+        });
+
+        it("should warn if imported layer has no feature", function(done) {
+            var files = [
+                  {name: 'name1.geojson', testing: true},
+                  {name: 'name2.geojson', testing: true}
+                ],
+                cberr = sinon.spy(),
+                cbloaded = sinon.spy();
+            loader.on('data:error', cberr);
+            loader.on('data:loaded', cbloaded);
+            var reader = loader.loadMultiple(files);
+            reader.onload({target: {result: _VALID_GEOJSON}});
+            reader.onload({target: {result: {}}});
+            assert.isTrue(cberr.calledOnce);
+            assert.isTrue(cbloaded.calledOnce);
+            done();
+        });
+
+        it("should silently ignore empty files list", function(done) {
+            var files = [],
+                callback = sinon.spy();
+            loader.on('data:error', callback);
+            loader.on('data:loaded', callback);
+            var reader = loader.loadMultiple(files);
+            assert.isFalse(reader);
+            assert.isFalse(callback.called);
+            done();
+        });
+    });
+
     describe('Load data', function() {
 
         beforeEach(function() {


### PR DESCRIPTION
This method was "private" inside FileLayerLoad control, but it is also useful independently of this class, for apps that implement file selectors or drag & drop themselves.
The new method could have been named "loadFiles", but then legacy "load" method should be renamed "loadFile" for consistency, which breaks backward compatibility.
I had to introduce an extra parameter to the load() method to use a single file reader in tests, so that test code can set result for each files.
