### PR TITLE
Fix to work with Leaflet 1.1

### DIFF
--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -241,7 +241,7 @@
         },
 
         onAdd: function (map) {
-            this.loader = L.Util.fileLoader(map, this.options);
+            this.loader = L.FileLayer.fileLoader(map, this.options);
 
             this.loader.on('data:loaded', function (e) {
                 // Fit bounds after loading
@@ -330,9 +330,10 @@
         }
     });
 
-    L.Util.FileLoader = FileLoader;
-    L.Util.fileLoader = function (map, options) {
-        return new L.Util.FileLoader(map, options);
+    L.FileLayer = {};
+    L.FileLayer.FileLoader = FileLoader;
+    L.FileLayer.fileLoader = function (map, options) {
+        return new L.FileLayer.FileLoader(map, options);
     };
 
     L.Control.FileLayerLoad = FileLayerLoad;

--- a/test/index.html
+++ b/test/index.html
@@ -12,8 +12,7 @@
   <script src="../node_modules/mocha/mocha.js"></script>
   <script src="../node_modules/sinon/pkg/sinon.js"></script>
   <script src="../node_modules/happen/happen.js"></script>
-  <script src="../node_modules/leaflet/build/deps.js"></script>
-  <script src="../node_modules/leaflet/debug/leaflet-include.js"></script>
+  <script src="../node_modules/leaflet/dist/leaflet.js"></script>
 
   <script src="../node_modules/togeojson/togeojson.js"></script>
   <script src="../src/leaflet.filelayer.js"></script>

--- a/test/test.filelayer.js
+++ b/test/test.filelayer.js
@@ -87,7 +87,7 @@ describe('FileLoader', function() {
 
     before(function() {
         map = L.map('map').fitWorld();
-        loader = new L.Util.FileLoader(map);
+        loader = new L.FileLayer.FileLoader(map);
     });
 
     after(function() {


### PR DESCRIPTION
Leaflet 1.1.0 switched to using Rollup as their bundler tool. It broke a number of plugins that depended on being able to install things in namespaces like `L.Util`. Leaflet.FileLayer was affected because it installs `L.Util.FileLoader` and `L.Util.fileLoader`.

This commit moves those into a new namespace: `L.FileLayer`.

It also changes the tests to adjust to where Rollup puts the Leaflet distribution.

See Leaflet/Leaflet#5589.