### PR TITLE
Prevent click propagation on all container

### DIFF
--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -320,7 +320,7 @@
                 this.value = '';
             }, false);
 
-            L.DomEvent.disableClickPropagation(link);
+            L.DomEvent.disableClickPropagation(container);
             L.DomEvent.on(link, 'click', function (e) {
                 fileInput.click();
                 e.preventDefault();


### PR DESCRIPTION
The deactivation of the click event propagation is only on the `<a> `element, it should be on the `div` container.