### PR TITLE
Update deprecated togeojson dependency

### DIFF
--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -27,9 +27,9 @@
             }
             if (toGeoJSON === undefined) {
                 if (typeof window !== 'undefined') {
-                    toGeoJSON = require('togeojson');
+                    toGeoJSON = require('@mapbox/togeojson');
                 } else {
-                    toGeoJSON = require('togeojson')(root);
+                    toGeoJSON = require('@mapbox/togeojson')(root);
                 }
             }
             factory(L, toGeoJSON);


### PR DESCRIPTION
npm WARN deprecated togeojson@0.14.2: This module has moved: please install @mapbox/togeojson instead