### PR TITLE
Adding support for capital case file extension.

### DIFF
--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -164,7 +164,7 @@
 
         _getParser: function (name, ext) {
             var parser;
-            ext = ext || name.split('.').pop();
+            ext = (ext || name.split('.').pop()).toLowerCase();
             parser = this._parsers[ext];
             if (!parser) {
                 this.fire('data:error', {


### PR DESCRIPTION
Currently only lowercased file extensions works, even when trying to explicitly allow other cases via `formats` option like so:

```
L.Control.fileLayerLoad({
  formats: ['.gpx', '.GPX']
}
```

Loading `filename.GPX` for example returns a `Unsupported file type (GPX)` error.

With this fix, the following configuration supports both `.gpx` or `.GPX`:
```
L.Control.fileLayerLoad({
  formats: ['.gpx']
}
```
