### PR TITLE
Fix creation and settings of geoJSON object

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ Usage
     var map = L.map('map').fitWorld();
     ...
     L.Control.fileLayerLoad({
-        // Allows you to use a customized version of L.geoJson.
+        // Allows you to use a customized version of L.GeoJSON.
         // For example if you are using the Proj4Leaflet leaflet plugin,
-        // you can pass L.Proj.geoJson and load the files into the
-        // L.Proj.GeoJson instead of the L.geoJson.
-        layer: L.geoJson,
-        // See http://leafletjs.com/reference.html#geojson-options
+        // you can pass L.Proj.GeoJSON and load the files into the
+        // L.Proj.GeoJSON instead of the L.geoJSON.
+        layer: L.geoJSON,
+        // See https://leafletjs.com/reference.html#geojson
         layerOptions: {style: {color:'red'}},
         // Add to map after loading (default: true) ?
         addToMap: true,

--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -41,7 +41,7 @@
 }(function fileLoaderFactory(L, toGeoJSON) {
     var FileLoader = L.Layer.extend({
         options: {
-            layer: L.geoJson,
+            layer: L.geoJSON,
             layerOptions: {},
             fileSizeLimit: 1024
         },

--- a/src/leaflet.filelayer.js
+++ b/src/leaflet.filelayer.js
@@ -198,7 +198,7 @@
             if (typeof content === 'string') {
                 content = JSON.parse(content);
             }
-            layer = this.options.layer(content, this.options.layerOptions);
+            layer = this.options.layer.addData(content, this.options.layerOptions);
 
             if (layer.getLayers().length === 0) {
                 throw new Error('GeoJSON has no valid layers.');


### PR DESCRIPTION
* Since [Leaflet 1.0-rc1](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#10-rc1-2016-04-18), there is a consistency in the naming of `GeoJSON` (NB: Proj4Leaflet is following the same naming convention)
* It's necessary to call `setData` method to set the content of the geoJSON 